### PR TITLE
Week 9 day 3: Add support for Open-Source LLM (Ollama / Llama 3) in RAG Chat API

### DIFF
--- a/Week9/api/routes/chat.py
+++ b/Week9/api/routes/chat.py
@@ -3,7 +3,7 @@ import logging
 
 from flask import Blueprint, Response, g, jsonify, request
 from langchain_community.vectorstores.pgvector import PGVector
-from scripts.constant import DEFAULT_CACHE_MODEL
+from scripts.constant import DEFAULT_CACHE_MODEL, DEFAULT_LLM_PROVIDER
 from scripts.data_loader import load_products
 from scripts.db_utils import SQLAlchemyCache, get_db_url, load_vector_store
 from scripts.embedding import embed_and_store
@@ -63,6 +63,8 @@ def chat_inventory() -> Response:
             return jsonify({"error": "Missing 'question'"}), 400
 
         question: str = data["question"]
+        provider: str = data.get("provider", DEFAULT_LLM_PROVIDER)
+
         current_user = g.current_user
         user_id: str = current_user.get("id") if current_user else None
         model: str = DEFAULT_CACHE_MODEL
@@ -93,8 +95,7 @@ def chat_inventory() -> Response:
         cache.save_response(
             prompt=question, response=answer, user_id=user_id, model=model
         )
-
-        return jsonify({"answer": answer, "cached": False})
+        return jsonify({"answer": answer, "cached": False, "provider": provider})
 
     except Exception as e:
         logger.exception(f"Unexpected error in /chat/inventory: {e}")

--- a/Week9/scripts/constant.py
+++ b/Week9/scripts/constant.py
@@ -6,7 +6,18 @@
 MODEL_NAME = "gpt-4o-mini"
 MODEL_NAME_EMBEDDING = "sentence-transformers/all-MiniLM-L6-v2"
 OPENAI_CHAT_MODEL = "gpt-4o-mini"
-OPENAI_TEMPERATURE = 0.0
+OPENAI_TEMPERATURE = 0.7
+
+# ==========================
+# Ollama Models
+# ==========================
+OLLAMA_MODEL = "llama3"
+OLLAMA_TEMPERATURE = 0.7
+
+# ==========================
+# Providers
+# ==========================
+DEFAULT_LLM_PROVIDER = "openai"  # can be "openai" or "ollama"
 
 # ==========================
 # Pricing
@@ -30,3 +41,8 @@ CHUNK_OVERLAP = 50
 # Cache Defaults
 # ==========================
 DEFAULT_CACHE_MODEL = "huggingface"
+
+# ==========================
+# Retriever
+# ==========================
+RETRIEVER_TOP_K = 10

--- a/Week9/scripts/llm_service.py
+++ b/Week9/scripts/llm_service.py
@@ -1,0 +1,39 @@
+import logging
+
+from langchain_community.chat_models import ChatOllama
+from langchain_openai import ChatOpenAI
+
+from .constant import (
+    DEFAULT_LLM_PROVIDER,
+    OLLAMA_MODEL,
+    OLLAMA_TEMPERATURE,
+    OPENAI_CHAT_MODEL,
+    OPENAI_TEMPERATURE,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LLMService:
+    """
+    Factory class for creating LLM clients (OpenAI, Ollama, etc.).
+    Adheres to OCP by allowing easy extension for new providers.
+    """
+
+    @staticmethod
+    def get_llm(provider: str = DEFAULT_LLM_PROVIDER):
+        """
+        Return the correct LLM client based on provider.
+
+        Args:
+            provider (str): "openai" or "ollama"
+
+        Returns:
+            ChatOpenAI | ChatOllama
+        """
+        if provider == "ollama":
+            logger.info("Using Ollama (Llama 3 local) as provider.")
+            return ChatOllama(model=OLLAMA_MODEL, temperature=OLLAMA_TEMPERATURE)
+
+        logger.info("Using OpenAI as provider.")
+        return ChatOpenAI(model=OPENAI_CHAT_MODEL, temperature=OPENAI_TEMPERATURE)

--- a/Week9/scripts/llm_service.py
+++ b/Week9/scripts/llm_service.py
@@ -20,6 +20,15 @@ class LLMService:
     Adheres to OCP by allowing easy extension for new providers.
     """
 
+    _llm_providers = {
+        "openai": lambda: ChatOpenAI(
+            model=OPENAI_CHAT_MODEL, temperature=OPENAI_TEMPERATURE
+        ),
+        "ollama": lambda: ChatOllama(
+            model=OLLAMA_MODEL, temperature=OLLAMA_TEMPERATURE
+        ),
+    }
+
     @staticmethod
     def get_llm(provider: str = DEFAULT_LLM_PROVIDER):
         """
@@ -31,9 +40,11 @@ class LLMService:
         Returns:
             ChatOpenAI | ChatOllama
         """
-        if provider == "ollama":
-            logger.info("Using Ollama (Llama 3 local) as provider.")
-            return ChatOllama(model=OLLAMA_MODEL, temperature=OLLAMA_TEMPERATURE)
+        if provider not in LLMService._llm_providers:
+            logger.warning(
+                f"Unknown provider '{provider}', defaulting to {DEFAULT_LLM_PROVIDER}"
+            )
+            provider = DEFAULT_LLM_PROVIDER
 
-        logger.info("Using OpenAI as provider.")
-        return ChatOpenAI(model=OPENAI_CHAT_MODEL, temperature=OPENAI_TEMPERATURE)
+        logger.info(f"Using '{provider}' as LLM provider.")
+        return LLMService._llm_providers[provider]()

--- a/Week9/scripts/rag_chain.py
+++ b/Week9/scripts/rag_chain.py
@@ -1,33 +1,43 @@
 # Week8/scripts/rag_chain.py
 import logging
+from typing import Union
 
 from dotenv import load_dotenv
 from langchain.schema import StrOutputParser
+from langchain_community.chat_models import ChatOllama
 from langchain_community.vectorstores.pgvector import PGVector
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import Runnable, RunnablePassthrough
 from langchain_openai import ChatOpenAI
 from prompts.system_prompt import RAG_PROMPT_TEMPLATE
 
-from .constant import (
-    OPENAI_CHAT_MODEL,
-    OPENAI_TEMPERATURE,
-)
+from .constant import DEFAULT_LLM_PROVIDER, RETRIEVER_TOP_K
+from .llm_service import LLMService
 
 load_dotenv()
 logger = logging.getLogger(__name__)
-# logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.INFO)
 
 
-def build_rag_chain(vector_store: PGVector) -> Runnable:
+def build_rag_chain(
+    vector_store: PGVector, provider: str = DEFAULT_LLM_PROVIDER
+) -> Runnable:
     """Build a Retrieval-Augmented Generation (RAG) chain."""
     try:
-        retriever = vector_store.as_retriever(search_kwargs={"k": 10})
+        retriever = vector_store.as_retriever(search_kwargs={"k": RETRIEVER_TOP_K})
+        logger.info(f"Retriever will fetch top {RETRIEVER_TOP_K} documents")
+
         prompt = ChatPromptTemplate.from_template(RAG_PROMPT_TEMPLATE)
-        llm = ChatOpenAI(model=OPENAI_CHAT_MODEL, temperature=OPENAI_TEMPERATURE)
+
+        llm: Union[ChatOpenAI, ChatOllama] = LLMService.get_llm(provider)
+        logger.info(f"Building RAG chain with LLM provider: {provider}")
 
         chain = (
-            {"context": retriever, "question": RunnablePassthrough()}
+            {
+                "context": retriever
+                | (lambda docs: "\n\n".join([doc.page_content for doc in docs])),
+                "question": RunnablePassthrough(),
+            }
             | prompt
             | llm
             | StrOutputParser()

--- a/docs/CODE_STRUCTURE.md
+++ b/docs/CODE_STRUCTURE.md
@@ -145,6 +145,8 @@ inventory-manager/
 │   |   |   ├── db_utils.py
 │   │   |   └── data_loader.py
 │   │   |   └── embedding.py
+│   │   |   └── embedding_service.py
+│   │   |   └── llm_service.py
 │   │   |   └── rag_chain.py
 │   │   |   └── constant.py
 │   ├── .env.example

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ langchain>=0.2.0
 langchain-openai>=0.1.0
 langchain-community>=0.2.0
 sentence-transformers>=3.0.0
+ollama>=0.1.8


### PR DESCRIPTION
## Changes:

1. Added LLMService factory to support multiple LLM providers (OpenAI, Ollama) → follows Open/Closed Principle.
2. Updated `rag_chain.py` to dynamically use selected provider for RAG chain.
3. Added constants in `constant.py` for Ollama settings and configurable retriever top-k.
4. Updated `/chat/inventory` route to accept optional "provider" in request JSON.
5. Caching and multi-tenant support preserved.
6. Tested locally with Ollama (Llama 3) and OpenAI models.
7. update `requirements.txt` and 'code_structure.md` for `week9 day3`.
## Usage Example:

{
  "question": "What products are available in food category?",
  "provider": "ollama"
}
## Screenshot
**ollama**
<img width="1920" height="1080" alt="Screenshot from 2025-09-10 12-10-48" src="https://github.com/user-attachments/assets/24c99a2c-fb4d-4a8e-ac56-22269a893379" />

**openai**
<img width="1920" height="1080" alt="Screenshot from 2025-09-10 12-11-40" src="https://github.com/user-attachments/assets/ef68361e-c851-4b90-8479-2045692aeb76" />